### PR TITLE
fix(ts-config-webpack-plugin): Set the maximum memory during tests to 512mb

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "lint-staged": "lint-staged",
         "lint": "prettier --list-different \"./packages/**/*.js\"",
         "posttest": "npm run lint",
-        "test": "lerna exec -- npm test",
+        "test": "lerna exec --concurrency 1 -- npm test",
         "update-snapshots": "lerna exec -- npm run update-snapshots",
         "clean": "lerna clean",
         "prettier": "prettier --write \"./packages/**/*.js\"",

--- a/packages/common-config-webpack-plugin/test/CommonConfigWebpackPlugin.test.js
+++ b/packages/common-config-webpack-plugin/test/CommonConfigWebpackPlugin.test.js
@@ -5,6 +5,8 @@ const CommonConfigWebpackPlugin = require('../src/CommonConfigWebpackPlugin');
 
 // Allow tests to run 30s
 jest.setTimeout(30000);
+// AppVeyor on Node6 will fail if the fork-ts-checker is not limited to 512 MB memory
+require('fork-ts-checker-webpack-plugin').DEFAULT_MEMORY_LIMIT = 512;
 
 beforeAll(done => {
 	rimraf(path.join(__dirname, 'fixtures/dist'), done);

--- a/packages/scss-config-webpack-plugin/src/ScssConfigWebpackPlugin.js
+++ b/packages/scss-config-webpack-plugin/src/ScssConfigWebpackPlugin.js
@@ -32,7 +32,7 @@ class ScssConfigWebpackPlugin {
 			? require('../config/production.config')(this.options)
 			: require('../config/development.config')(this.options);
 		// Merge config
-		config.plugins.forEach(plugin => plugin.apply(compiler));
+		compiler.options.plugins.push(...config.plugins);
 		compiler.hooks.afterEnvironment.tap('ScssConfigWebpackPlugin', () => {
 			compiler.options.module.rules.push(...config.module.rules);
 		});

--- a/packages/ts-config-webpack-plugin/src/TsConfigWebpackPlugin.js
+++ b/packages/ts-config-webpack-plugin/src/TsConfigWebpackPlugin.js
@@ -58,7 +58,7 @@ class TsConfigWebpackPlugin {
 			? require('../config/production.config')(options)
 			: require('../config/development.config')(options);
 		// Merge config
-		config.plugins.forEach(plugin => plugin.apply(compiler));
+		compiler.options.plugins.push(...config.plugins);
 		compiler.hooks.afterEnvironment.tap('TsConfigWebpackPlugin', () => {
 			compiler.options.module.rules.push(...config.module.rules);
 		});

--- a/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
+++ b/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
@@ -8,6 +8,8 @@ const validateSourcemap = require('sourcemap-validator');
 
 // Allow tests to run 30s
 jest.setTimeout(30000);
+// AppVeyor on Node6 will fail if the fork-ts-checker is not limited to 512 MB memory
+require('fork-ts-checker-webpack-plugin').DEFAULT_MEMORY_LIMIT = 512;
 
 beforeAll(done => {
 	rimraf(path.join(__dirname, 'fixtures/dist'), done);


### PR DESCRIPTION
This change seems to work well for appvejor