### PR TITLE
fix(scss-config-webpack-plugin): Prevent double scss loader execution

### DIFF
--- a/packages/scss-config-webpack-plugin/config/development.config.js
+++ b/packages/scss-config-webpack-plugin/config/development.config.js
@@ -55,7 +55,7 @@ exports = module.exports = options => ({
 				],
 			},
 			{
-				test: /module\.s?css$/,
+				test: /\.module\.s?css$/,
 				use: [
 					{
 						loader: require.resolve('style-loader'),

--- a/packages/scss-config-webpack-plugin/config/production.config.js
+++ b/packages/scss-config-webpack-plugin/config/production.config.js
@@ -56,7 +56,7 @@ exports = module.exports = options => ({
 				],
 			},
 			{
-				test: /module\.s?css$/,
+				test: /\.module\.s?css$/,
 				use: [
 					{
 						loader: MiniCssExtractPlugin.loader,


### PR DESCRIPTION
Fixes double parsing of files like `my-module.scss`.

Thanks @jhnns 