### PR TITLE
fix(ts-config-webpack-plugin): Fix "Debug Failure. False expression: Output generation failed"

### DIFF
--- a/packages/ts-config-webpack-plugin/src/TsConfigWebpackPlugin.js
+++ b/packages/ts-config-webpack-plugin/src/TsConfigWebpackPlugin.js
@@ -62,11 +62,16 @@ class TsConfigWebpackPlugin {
 		compiler.hooks.afterEnvironment.tap('TsConfigWebpackPlugin', () => {
 			compiler.options.module.rules.push(...config.module.rules);
 		});
-		// Prepend missing typescript file extensions
-		const typescriptExtensions = ['.ts', '.tsx', '.d.ts'].filter(
+		// Prepend missing typescript file extensions (high priority)
+		const typescriptPreExtensions = ['.ts', '.tsx'].filter(
 			ext => !compiler.options.resolve.extensions.includes(ext)
 		);
-		compiler.options.resolve.extensions.unshift(...typescriptExtensions);
+		compiler.options.resolve.extensions.unshift(...typescriptPreExtensions);
+		// Append missing definition type extensions (low priority)
+		const typescriptPostExtensions = ['.d.ts'].filter(
+			ext => !compiler.options.resolve.extensions.includes(ext)
+		);
+		compiler.options.resolve.extensions.push(...typescriptPostExtensions);
 	}
 }
 

--- a/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
+++ b/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
@@ -49,6 +49,17 @@ describe('TsConfigWebpackPlugin inside webpack context', () => {
 		});
 	});
 
+	it('should compile definition files without errors', done => {
+		const compiler = webpack({
+			context: path.join(__dirname, 'fixtures/definitions'),
+			plugins: [new TsConfigWebpackPlugin()],
+		});
+		compiler.run((err, stats) => {
+			expect(stats.compilation.errors).toEqual([]);
+			done();
+		});
+	});
+
 	it('should compile without errors in development mode', done => {
 		const compiler = webpack({
 			mode: 'development',

--- a/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/demo.d.ts
+++ b/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/demo.d.ts
@@ -1,0 +1,1 @@
+export declare function why(): string;

--- a/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/demo.js
+++ b/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/demo.js
@@ -1,0 +1,3 @@
+export function why() {
+	return 42;
+}

--- a/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/index.ts
+++ b/packages/ts-config-webpack-plugin/test/fixtures/definitions/src/index.ts
@@ -1,0 +1,3 @@
+import { why } from './demo';
+
+console.log(why());

--- a/packages/ts-config-webpack-plugin/test/fixtures/definitions/tsconfig.json
+++ b/packages/ts-config-webpack-plugin/test/fixtures/definitions/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"rootDir": "./"
+	}
+}


### PR DESCRIPTION
Currently when importing a `.js` file an omitting the extension webpack will add it for us automatically.  
For example `import { demo } from './demo'`  

However the current configuration tells webpack to prioritise `.d.ts` over `.js` files.  
This means if a `.js` and a `.d.ts` file with the same name exist it is not possible anymore to import the `.js` file without setting the extension.

Therefore typescript will run in very strange "Debug Failure. False expression: Output generation failed" errors.

This PR fixes it by decreasing the priority of `.d.ts` files.