### PR TITLE
feat(ts-config-webpack-plugin): Warn if skipLibCheck wasn't configured

### DIFF
--- a/packages/ts-config-webpack-plugin/package.json
+++ b/packages/ts-config-webpack-plugin/package.json
@@ -63,7 +63,6 @@
     "fork-ts-checker-webpack-plugin": "^0.4.8",
     "thread-loader": "^1.2.0",
     "ts-loader": "^4.4.2",
-    "tsconfig": "^7.0.0",
     "tslint": "^5.10.0"
   },
   "devDependencies": {

--- a/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
+++ b/packages/ts-config-webpack-plugin/test/TsConfigWebpackPlugin.test.js
@@ -168,6 +168,22 @@ describe('TsConfigWebpackPlugin inside webpack context', () => {
 		expect(ruleToTest.test.test('testingts')).toBe(false);
 		done();
 	});
+
+	it('should warn if --skipLibCheck is not specified', (done) => {
+		const origWarn = console.warn;
+		let warnMessage;
+		console.warn = (msg) => (warnMessage = msg);
+		const compiler = webpack({
+			context: path.join(__dirname, 'fixtures/no-lib-check'),
+			plugins: [new TsConfigWebpackPlugin()],
+		});
+		compiler.run((err, stats) => {
+			console.warn = origWarn;
+			expect(Boolean(warnMessage)).toEqual(true);
+			expect(warnMessage).toMatchSnapshot();
+			done();
+		});
+	});
 });
 
 describe('TsConfigWebpackPlugin sourcemaps', () => {

--- a/packages/ts-config-webpack-plugin/test/__snapshots__/TsConfigWebpackPlugin.test.js.snap
+++ b/packages/ts-config-webpack-plugin/test/__snapshots__/TsConfigWebpackPlugin.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TsConfigWebpackPlugin inside webpack context should warn if --skipLibCheck is not specified 1`] = `
+"Warning: skipLibCheck option was NOT specified
+By default the fork-ts-checker-webpack-plugin will check all types inside the node_modules directory
+even for unused dependencies and slow down the type checking a lot.
+To skip that checking add the following line to your tsconfig.json compilerOptions configuration:
+\\"skipLibCheck\\": true
+To keep the default behaviour with possible performance penalties set skipLibCheck to false to hide this warning."
+`;

--- a/packages/ts-config-webpack-plugin/test/fixtures/no-lib-check/src/index.ts
+++ b/packages/ts-config-webpack-plugin/test/fixtures/no-lib-check/src/index.ts
@@ -1,0 +1,24 @@
+export interface IEntry<T> {
+	key: string;
+	value: T;
+}
+
+export class Entry<T> implements IEntry<T> {
+	constructor(private $key: string, private $value: T) {}
+
+	get key(): string {
+		return this.$key;
+	}
+
+	get value(): any {
+		return this.$value;
+	}
+}
+
+export const test = () => {
+	const a = new Entry('a', 2);
+	const b = new Entry('b', 4);
+	const c = new Entry('b', 6);
+
+	return [a, b, c].map((entry: Entry<number>) => entry.value * 2).every((value: number) => value > 0);
+};

--- a/packages/ts-config-webpack-plugin/test/fixtures/no-lib-check/tsconfig.json
+++ b/packages/ts-config-webpack-plugin/test/fixtures/no-lib-check/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../../tsconfig.json",
 	"compilerOptions": {
 		"declaration": true,
-		"rootDir": "./",
-		"skipLibCheck": true
+		"rootDir": "./"
 	}
 }

--- a/packages/ts-config-webpack-plugin/test/fixtures/simple/tsconfig.json
+++ b/packages/ts-config-webpack-plugin/test/fixtures/simple/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../../tsconfig.json",
 	"compilerOptions": {
 		"declaration": true,
-		"rootDir": "./"
+		"rootDir": "./",
+		"skipLibCheck": true
 	}
 }

--- a/webpage/webpack.config.js
+++ b/webpage/webpack.config.js
@@ -18,9 +18,7 @@ module.exports = (_, { mode }) => ({
 		// see https://github.com/namics/webpack-config-plugins/tree/master/packages/ts-config-webpack-plugin/config
 		new TsConfigWebpackPlugin(),
 		// Offline Caching
-		mode === 'production'
-			? new OfflinePlugin()
-			: EmptyPlugin,
+		mode === 'production' ? new OfflinePlugin() : EmptyPlugin,
 		new HtmlWebpackPlugin({ template: 'CNAME', inject: false, filename: 'CNAME' }),
 	],
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
```
[x] Feature
```

## What is the new behavior?

Setting `skipLibCheck` to `true` can improve the performance of type checking a lot (see https://github.com/webpack/webpack/issues/8421 for details).

This pull request adds a warning and asks the developer to decide wether they want `skipLibCheck` to be enabled or disabled.

If he explicitly disables or enables the setting the warning will not be displayed.

## Does this PR introduce a breaking change?

```
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This pull request switches from the `tsconfig` plugin to the `typescript` plugin to resolve the typescript config file.
