### PR TITLE
fix(ts-config-webpack-plugin): Add missing module-resolution property

### DIFF
--- a/packages/ts-config-webpack-plugin/config/tsconfig.base.json
+++ b/packages/ts-config-webpack-plugin/config/tsconfig.base.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"suppressOutputPathCheck": true
+		"suppressOutputPathCheck": true,
+		"moduleResolution": "node"
 	}
 }


### PR DESCRIPTION
Add missing nodeModule resolution to hide the resolution warning