### PR TITLE
ci: Use prepare instead of postinstall and disable ci mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: node_js
 sudo: false
 
+os:
+  - linux
+
 node_js:
   - '10'
   - '8'
   - '6'
 
-os:
-  - linux
+before_install:
+  - npm i -g npm@6.4.1
+
+install:
+  - travis_retry npm install
+  - travis_retry npm run bootstrap
+
 
 stages:
   - test
@@ -17,10 +25,8 @@ jobs:
   include:
 
     - stage: test
-      before_install:
-      - npm i -g npm@6.4.1
-      install:
-      - travis_retry npm install
+      script:
+        - npm test
 
     - stage: performance
       name: "webpack-dev-server typescript"
@@ -31,6 +37,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:
@@ -45,6 +52,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:
@@ -60,6 +68,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:
@@ -75,6 +84,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:
@@ -89,6 +99,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:
@@ -103,6 +114,7 @@ jobs:
         - '10'
       install:
         - travis_retry npm install
+        - travis_retry npm run bootstrap
         - cd performance
         - travis_retry npm install
       script:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "clean:modules": "npx rimraf node_modules",
     "commit": "git-cz",
     "lint": "npm run prettier",
-    "postinstall": "npm run bootstrap",
     "posttest": "npm run lint",
     "test": "lerna exec --concurrency 1 -- npm test",
     "update-snapshots": "lerna exec -- npm run update-snapshots",


### PR DESCRIPTION
Prevent travis from hanging in a install loop.