### PR TITLE
docs(cli): Add additional getting started information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 **/package-lock.json
 dist
 build
+tmp
 
 # editors
 .vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,7 @@
 **/build
 **/dist
 **/public
+**/tmp
 **/coverage
 **/.publish
 **/performance/environments/*/src/components

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Instead of copying loader configs from github and stackoverflow you could just a
 <br>
 </div>
 
+## Quick overview
+
+```
+npx generate-webpack-config
+```
+
+Alternatively you can also use the [online config tool](https://webpack-config-plugins.js.org/) to get started.
+
+
 ## Zero Config example
 
 Webpack itself provides many defaults so you are able to run the `common-config-webpack-plugin` without a webpack.config file:

--- a/cli/cli/generate-webpack-config.ts
+++ b/cli/cli/generate-webpack-config.ts
@@ -1,0 +1,6 @@
+import { generateConfigCli } from '../src';
+
+generateConfigCli().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+};

--- a/cli/package.json
+++ b/cli/package.json
@@ -53,10 +53,15 @@
     "test": "tsc"
   },
   "devDependencies": {
+    "@types/jest": "23.3.13",
     "@types/node": "10.12.18",
     "@types/webpack": "4.4.21",
     "inquirer": "6.2.1",
+    "jest": "23.6.0",
+    "mock-fs" : "4.7.0",
     "pkg-ok": "2.3.1",
+    "rimraf": "2.6.3",
+    "ts-jest": "23.10.5",
     "ts-config-webpack-plugin": "^1.2.1",
     "typescript": "3.2.2",
     "webpack": "4.21.0",
@@ -65,5 +70,8 @@
   "engines": {
     "npm": ">=5",
     "node": ">=6"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/cli/src/__snapshots__/index.test.ts.snap
+++ b/cli/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,420 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useJs","useScss","useTs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  clean-webpack-plugin common-config-webpack-plugin html-webpack-plugin webpack webpack-cli webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
+💡  Build your bundle with    webpack --mode production
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useScss","useJs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react asset-config-webpack-plugin clean-webpack-plugin html-webpack-plugin js-config-webpack-plugin scss-config-webpack-plugin webpack webpack-cli webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
+💡  Build your bundle with    webpack --mode production
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useScss","useTs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  asset-config-webpack-plugin clean-webpack-plugin html-webpack-plugin scss-config-webpack-plugin ts-config-webpack-plugin typescript webpack webpack-cli webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
+💡  Build your bundle with    webpack --mode production
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useCli","useJs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react js-config-webpack-plugin webpack webpack-cli
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
+💡  Build your bundle with    webpack --mode production
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useCli","useTs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  ts-config-webpack-plugin typescript webpack webpack-cli
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
+💡  Build your bundle with    webpack --mode production
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useDevServer","useJs","useImages","useScss"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react image-config-webpack-plugin js-config-webpack-plugin scss-config-webpack-plugin webpack webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useDevServer","useJs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react js-config-webpack-plugin webpack webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useDevServer","useTs","useImages","useScss"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  image-config-webpack-plugin scss-config-webpack-plugin ts-config-webpack-plugin typescript webpack webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it logs a understandable instruction if webpack.config.js content is written {"options":["useDevServer","useTs"]} 1`] = `
+"
+✍️  Creating \\"webpack.config.js\\"
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  ts-config-webpack-plugin typescript webpack webpack-dev-server
+
+
+Next steps:
+💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
+💡  Start the server with     webpack-dev-server --mode development
+💡  For more information on avaialble modes please go to https://webpack.js.org/concepts/mode/
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useJs","useScss","useTs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const CommonConfigWebpackPlugin = require('common-config-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // Cleans the dist folder before the build starts
+    new CleanWebpackPlugin(['dist']),
+    // Multi threading babel loader configuration with caching for .js and .jsx files
+    // Multi threading typescript loader configuration with caching for .ts and .tsx files
+    // SCSS Configuration for .css .module.css and .scss .module.scss files
+    // File loader configuration for .woff and .woff2 files
+    // File loader configuration for .gif .jpg .jpeg .png and .svg files
+    // https://github.com/namics/webpack-config-plugins/
+    new CommonConfigWebpackPlugin(),
+    // Generate a base html file and injects all generated css and js files
+    new HtmlWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  clean-webpack-plugin common-config-webpack-plugin html-webpack-plugin webpack webpack-cli webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useScss","useJs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const AssetConfigWebpackPlugin = require('asset-config-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
+const ScssConfigWebpackPlugin = require('scss-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // File loader configuration for .woff and .woff2 files
+    // File loader configuration for .gif .jpg .jpeg .png and .svg files
+    // https://github.com/namics/webpack-config-plugins/tree/master/packages/asset-config-webpack-plugin
+    new AssetConfigWebpackPlugin(),
+    // Cleans the dist folder before the build starts
+    new CleanWebpackPlugin(['dist']),
+    // Generate a base html file and injects all generated css and js files
+    new HtmlWebpackPlugin(),
+    // Multi threading babel loader configuration with caching for .js and .jsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/js-config-webpack-plugin/config
+    new JsConfigWebpackPlugin(),
+    // SCSS Configuration for .css .module.css and .scss .module.scss files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/scss-config-webpack-plugin/config
+    new ScssConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react asset-config-webpack-plugin clean-webpack-plugin html-webpack-plugin js-config-webpack-plugin scss-config-webpack-plugin webpack webpack-cli webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useClean","useCli","useCss","useDevServer","useFonts","useHtml","useImages","useScss","useTs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const AssetConfigWebpackPlugin = require('asset-config-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ScssConfigWebpackPlugin = require('scss-config-webpack-plugin');
+const TsConfigWebpackPlugin = require('ts-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // File loader configuration for .woff and .woff2 files
+    // File loader configuration for .gif .jpg .jpeg .png and .svg files
+    // https://github.com/namics/webpack-config-plugins/tree/master/packages/asset-config-webpack-plugin
+    new AssetConfigWebpackPlugin(),
+    // Cleans the dist folder before the build starts
+    new CleanWebpackPlugin(['dist']),
+    // Generate a base html file and injects all generated css and js files
+    new HtmlWebpackPlugin(),
+    // SCSS Configuration for .css .module.css and .scss .module.scss files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/scss-config-webpack-plugin/config
+    new ScssConfigWebpackPlugin(),
+    // Multi threading typescript loader configuration with caching for .ts and .tsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/ts-config-webpack-plugin/config
+    new TsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  asset-config-webpack-plugin clean-webpack-plugin html-webpack-plugin scss-config-webpack-plugin ts-config-webpack-plugin typescript webpack webpack-cli webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useCli","useJs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // Multi threading babel loader configuration with caching for .js and .jsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/js-config-webpack-plugin/config
+    new JsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react js-config-webpack-plugin webpack webpack-cli
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useCli","useTs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const TsConfigWebpackPlugin = require('ts-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // Multi threading typescript loader configuration with caching for .ts and .tsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/ts-config-webpack-plugin/config
+    new TsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  ts-config-webpack-plugin typescript webpack webpack-cli
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useDevServer","useJs","useImages","useScss"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const ImagesConfigWebpackPlugin = require('image-config-webpack-plugin');
+const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
+const ScssConfigWebpackPlugin = require('scss-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // File loader configuration for .gif .jpg .jpeg .png and .svg files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/image-config-webpack-plugin/config
+    new ImagesConfigWebpackPlugin(),
+    // Multi threading babel loader configuration with caching for .js and .jsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/js-config-webpack-plugin/config
+    new JsConfigWebpackPlugin(),
+    // SCSS Configuration for .css .module.css and .scss .module.scss files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/scss-config-webpack-plugin/config
+    new ScssConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react image-config-webpack-plugin js-config-webpack-plugin scss-config-webpack-plugin webpack webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useDevServer","useJs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // Multi threading babel loader configuration with caching for .js and .jsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/js-config-webpack-plugin/config
+    new JsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react js-config-webpack-plugin webpack webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useDevServer","useTs","useImages","useScss"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const ImagesConfigWebpackPlugin = require('image-config-webpack-plugin');
+const ScssConfigWebpackPlugin = require('scss-config-webpack-plugin');
+const TsConfigWebpackPlugin = require('ts-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // File loader configuration for .gif .jpg .jpeg .png and .svg files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/image-config-webpack-plugin/config
+    new ImagesConfigWebpackPlugin(),
+    // SCSS Configuration for .css .module.css and .scss .module.scss files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/scss-config-webpack-plugin/config
+    new ScssConfigWebpackPlugin(),
+    // Multi threading typescript loader configuration with caching for .ts and .tsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/ts-config-webpack-plugin/config
+    new TsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  image-config-webpack-plugin scss-config-webpack-plugin ts-config-webpack-plugin typescript webpack webpack-dev-server
+
+"
+`;
+
+exports[`cli it output the correct webpack.config.js content for {"options":["useDevServer","useTs"]} 1`] = `
+"
+⚠️ Skipping writing webpack.config.js
+💡  Add the following code to your webpack.config.js:
+
+const TsConfigWebpackPlugin = require('ts-config-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    // Multi threading typescript loader configuration with caching for .ts and .tsx files
+    // see https://github.com/namics/webpack-config-plugins/tree/master/packages/ts-config-webpack-plugin/config
+    new TsConfigWebpackPlugin(),
+  ],
+};
+
+
+⚠️  Skipping NPM installation
+💡  To install the dependencies manually run:
+
+npm install --save-dev  ts-config-webpack-plugin typescript webpack webpack-dev-server
+
+"
+`;

--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -1,0 +1,93 @@
+import * as inquirer from 'inquirer';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as rimraf from 'rimraf';
+import { generateConfigCli } from '.';
+import { ConfigOptionKeys } from './config-generator';
+
+// Fix invalid mockFs typings
+jest.mock('inquirer');
+
+let folderIndex = 0;
+function generateTmpFolder(name = String(folderIndex++)) {
+	const tmpFolder = path.resolve(__dirname, '../tmp');
+	const tmpSubFolder = path.join(tmpFolder, name);
+	rimraf.sync(tmpSubFolder);
+	try {
+		fs.mkdirSync(tmpFolder);
+	} catch (e) {}
+	try {
+		fs.mkdirSync(tmpSubFolder);
+	} catch (e) {}
+	return tmpSubFolder;
+}
+
+function mergeLoggerMockCalls(fn: ReturnType<typeof jest.fn>) {
+	return fn.mock.calls.reduce((result, call) => result + call.join(' ') + '\n', '\n');
+}
+
+type InquirerQuestions = { options: Array<ConfigOptionKeys>; overwrite: 'yes' | 'no'; install: 'yes' | 'no' };
+const mockInquirer = (mockAnswers: Partial<InquirerQuestions>) => {
+	inquirer.prompt.mockImplementation(async (questions: Array<{ name: string }>) => {
+		if (questions.length !== 1) {
+			throw new Error('Can only mock single questions');
+		}
+		const answer = (mockAnswers as any)[questions[0].name];
+		if (typeof answer === undefined) {
+			throw new Error('Missing mock for ' + questions[0].name);
+		}
+		return {
+			[questions[0].name]: answer,
+		};
+	});
+};
+
+// Combinations to test
+// prettier-ignore
+const combinations: Array<{ options: Array<ConfigOptionKeys> }> = [
+	{ options: ['useClean','useCli','useCss','useDevServer','useFonts','useHtml','useImages','useJs','useScss','useTs'] },
+	{ options: ['useClean','useCli','useCss','useDevServer','useFonts','useHtml','useImages','useScss','useTs'] },
+	{ options: ['useClean','useCli','useCss','useDevServer','useFonts','useHtml','useImages','useScss','useJs'] },
+	{ options: ['useCli', 'useTs'] },
+	{ options: ['useCli', 'useJs'] },
+	{ options: ['useDevServer', 'useTs'] },
+	{ options: ['useDevServer', 'useJs'] },
+	{ options: ['useDevServer', 'useTs', 'useImages', 'useScss'] },
+	{ options: ['useDevServer', 'useJs', 'useImages', 'useScss'] },
+];
+
+describe('cli', () => {
+	test.each(combinations as any)(
+		`it should run without errors for options %j`,
+		async ({ options }: { options: Array<ConfigOptionKeys> }) => {
+			const logger = jest.fn();
+			console.log = logger;
+			mockInquirer({ options, overwrite: 'no', install: 'no' });
+			await generateConfigCli(process.cwd());
+			expect(logger.mock.calls.length).not.toBe(0);
+		}
+	);
+
+	test.each(combinations as any)(
+		`it output the correct webpack.config.js content for %j`,
+		async ({ options }: { options: Array<ConfigOptionKeys> }) => {
+			const logger = jest.fn();
+			console.log = logger;
+			mockInquirer({ options, overwrite: 'no', install: 'no' });
+			await generateConfigCli(process.cwd());
+			expect(mergeLoggerMockCalls(logger)).toMatchSnapshot();
+		}
+	);
+
+	test.each(combinations as any)(
+		`it logs a understandable instruction if webpack.config.js content is written %j`,
+		async ({ options }: { options: Array<ConfigOptionKeys> }) => {
+			const tmpSubFolder = generateTmpFolder(options.join('-'));
+			const logger = jest.fn();
+			console.log = logger;
+			mockInquirer({ options, overwrite: 'yes', install: 'no' });
+			await generateConfigCli(tmpSubFolder);
+			expect(mergeLoggerMockCalls(logger)).toMatchSnapshot();
+		}
+	);
+});

--- a/cli/webpack.config.js
+++ b/cli/webpack.config.js
@@ -4,6 +4,9 @@ const webpack = require('webpack');
 module.exports = {
 	mode: 'production',
 	target: 'node',
+	entry: {
+		main: './cli/generate-webpack-config.ts',
+	},
 	output: {
 		filename: 'generate-webpack-config.js',
 	},


### PR DESCRIPTION
The readme promotes the usage of the cli:

https://github.com/namics/webpack-config-plugins/blob/d34d61398dac64750f55dc6d42f99080c6190721/README.md#L31-L39

The cli now contains next steps to get started:

https://github.com/namics/webpack-config-plugins/blob/d34d61398dac64750f55dc6d42f99080c6190721/cli/src/__snapshots__/index.test.ts.snap#L136-L146