### PR TITLE
fix(js-config-webpack-plugin): Fix babel internal API call failing fo…

### DIFF
--- a/packages/js-config-webpack-plugin/package.json
+++ b/packages/js-config-webpack-plugin/package.json
@@ -61,7 +61,7 @@
     "thread-loader": "^2.1.1"
   },
   "devDependencies": {
-    "@babel/core": "7.2.2",
+    "@babel/core": "7.9.0",
     "@babel/preset-env": "7.2.3",
     "@babel/preset-react": "7.0.0",
     "@types/jest": "23.3.13",

--- a/packages/js-config-webpack-plugin/src/JsConfigWebpackPlugin.js
+++ b/packages/js-config-webpack-plugin/src/JsConfigWebpackPlugin.js
@@ -33,13 +33,37 @@ class JsConfigWebpackPlugin {
 	 * @returns {string}
 	 */
 	resolveBabelConfigFilePath(contextPath, environmentName) {
+		/**
+		 * Return the value, unless its an interator, in which case get the last value.
+		 * Works around differences in return values of @babel/core functions between versions.
+		 * @param {any} valueOrIterator A value, or a generator that will return the value.
+		 */
+		function getResult(valueOrIterator) {
+			if (!isGenerator(valueOrIterator)) {
+				return valueOrIterator;
+			}
+			let result = valueOrIterator.next();
+			while (!result.done) {
+				result = valueOrIterator.next();
+			}
+			return result.value;
+		}
+
+		/**
+		 * Returns true if the value looks like a generator.
+		 * @param {any} val
+		 */
+		function isGenerator(val) {
+			return val && typeof val === 'object' && typeof val.next === 'function';
+		}
+
 		// From https://github.com/babel/babel/blob/52a569056c6008c453bf26219461655c7d0322c4/packages/babel-core/src/config/files/package.js#L15
-		const packageData = findPackageData(contextPath);
+		const packageData = getResult(findPackageData(contextPath));
 		// needed because babels `findRelativeConfig` search just in parent directories
 		packageData.directories.push(packageData.filepath);
 		// From https://github.com/babel/babel/blob/52a569056c6008c453bf26219461655c7d0322c4/packages/babel-core/src/config/files/configuration.js#L26
-		const resolvedRelativeConfig = findRelativeConfig(packageData, environmentName);
-		const resolvedRootConfig = findRootConfig(packageData.filepath, environmentName);
+		const resolvedRelativeConfig = getResult(findRelativeConfig(packageData, environmentName));
+		const resolvedRootConfig = getResult(findRootConfig(packageData.filepath, environmentName));
 
 		// babel.config.js
 		if (resolvedRootConfig && resolvedRootConfig.filepath) {


### PR DESCRIPTION
…r newer bable versions

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: link tbd.
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] tooling / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Resolves #71 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Haven't added a test as this relies on changes to dependencies.

No relevant change to docs needed as far as I can tell as no functionality has changed.

I have fixed the version number of `@babel-core` as a minor version update to that is what caused the issue - The usage of `findPackageData` from `@babel/core 7.8.4` (and perhaps earlier) is incompatible with `7.2.2`.

I'm not super fluent when it comes to peer dependencies so you may want to confirm the changes there in more detail.

As mentioned in the original ticket, you may want to refer to [282f81bd676d09c1d8c48b08a7254b961eb41bed](https://github.com/babel/babel/commit/282f81bd676d09c1d8c48b08a7254b961eb41bed) in `@babel-core` as part of this PR.

I haven't included `package-lock.json` in this commit, however it is now picked up by git since its removal from `.gitignore` - let me know if you want it included.