### PR TITLE
Fix broken dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -62,7 +62,8 @@
     "ts-jest": "23.10.5",
     "typescript": "4.2.3",
     "webpack": "4.46.0",
-    "webpack-cli": "4.6.0"
+    "webpack-cli": "4.6.0",
+    "webpack-dev-server": "3.11.2"
   },
   "engines": {
     "npm": ">=6",

--- a/cli/src/__snapshots__/index.test.ts.snap
+++ b/cli/src/__snapshots__/index.test.ts.snap
@@ -14,7 +14,7 @@ npm install --save-dev  clean-webpack-plugin common-config-webpack-plugin html-w
 Next steps:
 💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
 💡  Build your bundle with    webpack --mode production
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -33,7 +33,7 @@ npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react asset-
 Next steps:
 💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
 💡  Build your bundle with    webpack --mode production
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -52,7 +52,7 @@ npm install --save-dev  asset-config-webpack-plugin clean-webpack-plugin html-we
 Next steps:
 💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
 💡  Build your bundle with    webpack --mode production
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -106,7 +106,7 @@ npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react image-
 
 Next steps:
 💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -124,7 +124,7 @@ npm install --save-dev  @babel/core @babel/preset-env @babel/preset-react js-con
 
 Next steps:
 💡  Webpack will look for \\"src/index.js\\" which you have to create manually.
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -142,7 +142,7 @@ npm install --save-dev  image-config-webpack-plugin scss-config-webpack-plugin t
 
 Next steps:
 💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;
@@ -160,7 +160,7 @@ npm install --save-dev  ts-config-webpack-plugin typescript webpack webpack-dev-
 
 Next steps:
 💡  Webpack will look for \\"src/index.ts\\" or \\"src/index.tsx\\" which you have to create manually.
-💡  Start the server with     webpack-dev-server --mode development
+💡  Start the server with     webpack serve --mode development
 💡  For more information on available modes please go to https://webpack.js.org/concepts/mode/
 "
 `;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -118,7 +118,7 @@ export const generateConfigCli = async (cwd = process.cwd()) => {
 			console.log('💡  Build your bundle with    webpack --mode production');
 		}
 		if (configOptions.useDevServer) {
-			console.log('💡  Start the server with     webpack-dev-server --mode development');
+			console.log('💡  Start the server with     webpack serve --mode development');
 		}
 		if (configOptions.useCli || configOptions.useDevServer) {
 			console.log(

--- a/packages/common-config-webpack-plugin/test/fixtures/simple/empty.ts
+++ b/packages/common-config-webpack-plugin/test/fixtures/simple/empty.ts
@@ -1,0 +1,1 @@
+// This is a placeholder file to satisfy typescript

--- a/packages/common-config-webpack-plugin/test/fixtures/simple/tsconfig.json
+++ b/packages/common-config-webpack-plugin/test/fixtures/simple/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"suppressOutputPathCheck": true,
 		"moduleResolution": "node"
 	}
 }

--- a/packages/scss-config-webpack-plugin/package.json
+++ b/packages/scss-config-webpack-plugin/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "autoprefixer": "^9.4.3",
-    "css-loader": "^1.0.0",
+    "css-loader": "^5.2.0",
     "iconfont-webpack-plugin": "4.2.2",
     "mini-css-extract-plugin": "0.9.0",
     "node-sass": "^4.9.0",

--- a/packages/scss-config-webpack-plugin/test/__snapshots__/ScssConfigWebpackPlugin.test.js.snap
+++ b/packages/scss-config-webpack-plugin/test/__snapshots__/ScssConfigWebpackPlugin.test.js.snap
@@ -10,8 +10,8 @@ exports[`ScssConfigWebpackPlugin inside webpack context should avoid common flex
 
 exports[`ScssConfigWebpackPlugin inside webpack context should avoid common flexbox bugs in older browsers in production mode 1`] = `".foo{display:flex;flex-direction:row;flex:1 1}"`;
 
-exports[`ScssConfigWebpackPlugin inside webpack context should generate a valid font path 1`] = `"@font-face{font-family:OpenSans;src:url(c8ffdeb3144d5055756ef01ef98e8486.woff)}"`;
+exports[`ScssConfigWebpackPlugin inside webpack context should generate a valid font path 1`] = `"@font-face{font-family:OpenSans;src:url(ab6e9d5d7db5dfffc24d3b8c57d5619c.woff)}"`;
 
-exports[`ScssConfigWebpackPlugin inside webpack context should generate a valid font path for subfolders 1`] = `"@font-face{font-family:OpenSans;src:url(../../c8ffdeb3144d5055756ef01ef98e8486.woff)}"`;
+exports[`ScssConfigWebpackPlugin inside webpack context should generate a valid font path for subfolders 1`] = `"@font-face{font-family:OpenSans;src:url(../../ab6e9d5d7db5dfffc24d3b8c57d5619c.woff)}"`;
 
 exports[`ScssConfigWebpackPlugin inside webpack context should generate separate CSS files with the correct contents 1`] = `".test{height:5px}"`;

--- a/packages/ts-config-webpack-plugin/config/tsconfig.base.json
+++ b/packages/ts-config-webpack-plugin/config/tsconfig.base.json
@@ -3,7 +3,6 @@
 		"module": "esnext",
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"suppressOutputPathCheck": true,
 		"moduleResolution": "node",
 		"jsx": "react"
 	}

--- a/performance/measure-dev-server.js
+++ b/performance/measure-dev-server.js
@@ -37,7 +37,7 @@ async function sleep(time) {
  * https://mermaidjs.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVERcblx0U3Bhd25bU3Bhd24gd2VicGFjay1kZXYtc2VydmVyXSAtLT58SW5pdGlhbCBDb21waWxlfCBXYWl0KFdhaXQgZm9yOiAnQ29tcGlsZWQgc3VjY2Vzc2Z1bGx5Jylcblx0V2FpdCAtLT4gTWVhc3VyZShNZWFzdXJlIHRpbWUpXG5cdE1lYXN1cmUgLS0-IFNsZWVwKFdhaXQgZm9yIDE1MDBtcylcblx0U2xlZXAgLS0-IFRyaWdnZXJCdWlsZChNb2RpZnkgYSB3YXRjaGVkIGZpbGUpXG5cdFRyaWdnZXJCdWlsZCAtLT4gfEluY3JlbWVudGFsIGNvbXBpbGV8IFdhaXRcbiIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19
  *
  * graph TD
-	Spawn[Spawn webpack-dev-server] -->|Initial Compile| Wait(Wait for: 'Compiled successfully')
+	Spawn[Spawn webpack serve] -->|Initial Compile| Wait(Wait for: 'Compiled successfully')
 	Wait --> Measure(Measure time)
 	Measure --> Sleep(Wait for 1500ms)
 	Sleep --> TriggerBuild(Modify a watched file)
@@ -53,7 +53,8 @@ async function launchWebpackDevServer(args, environmentName, onReady) {
 		const webpackDevServerProcess = spawn(
 			'node',
 			[
-				path.resolve(`environments/${environmentName}/node_modules/webpack-dev-server/bin/webpack-dev-server`),
+				path.resolve(`environments/${environmentName}/node_modules/webpack/bin/webpack`),
+				'serve',
 			].concat(args.split(' ')),
 			{
 				stdio: ['pipe', 'pipe', 'inherit'],

--- a/webpage/package.json
+++ b/webpage/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "cleanup": "npx rimraf .publish",
-    "start": "webpack-dev-server --mode development",
+    "start": "webpack serve --mode development",
     "build": "webpack --mode production --devtool sourcemap",
     "deploy": "npx npm-run-all cleanup build deploy:github",
     "deploy:github": "node node_modules/.bin/deploy-gh-pages"


### PR DESCRIPTION
Sorry I'm ditching the normal PR template and just going to write here that I found and fixed the issues happening in the CI builds on the `fix/maintenance` branch. Hopefully the way I have resolved it below is acceptable.

The specific error seen in https://ci.appveyor.com/project/namics/webpack-config-plugins/builds/38489089 required `css-loader` in `packages/scss-config-webpack-plugin/package.json` to be a newer version. Once that check passed there were typescript errors caused by the use of `suppressOutputPathCheck` which is no longer a valid option to use, but in order to not receive errors when removing `suppressOutputPathCheck` a file had to be added `packages/common-config-webpack-plugin/test/fixtures/simple/empty.ts`

New Info: https://github.com/webpack/webpack-dev-server/issues/2975
`webpack-dev-server` is replaced with `webpack serve` when using via cli.